### PR TITLE
Proper responses for incorrect values

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -25,6 +25,14 @@ matrix:
           env: LARAVEL='6.*' TESTBENCH='4.*' COMPOSER_FLAGS='--prefer-stable'
         - php: 7.3
           env: LARAVEL='7.*' TESTBENCH='5.*' COMPOSER_FLAGS='--prefer-stable'
+        - php: 7.4
+          env: LARAVEL='7.*' TESTBENCH='5.*' COMPOSER_FLAGS='--prefer-stable'
+        - php: 7.4
+          env: LARAVEL='7.*' TESTBENCH='6.*' COMPOSER_FLAGS='--prefer-stable'
+        - php: 7.4
+          env: LARAVEL='8.*' TESTBENCH='6.*' COMPOSER_FLAGS='--prefer-stable'
+        - php: 8.0
+          env: LARAVEL='8.*' TESTBENCH='6.*' COMPOSER_FLAGS='--prefer-stable'
 
 before_install:
     - travis_retry composer self-update

--- a/composer.json
+++ b/composer.json
@@ -18,7 +18,7 @@
         }
     ],
     "require": {
-        "php": "^7.2",
+        "php": "^7.2|^8.0",
         "illuminate/support": "~5.8.0|^6.0|^7.0|^8.0",
         "spatie/laravel-webhook-client": "^2.0"
     },

--- a/src/MailgunSignatureValidator.php
+++ b/src/MailgunSignatureValidator.php
@@ -33,7 +33,8 @@ class MailgunSignatureValidator implements SignatureValidator
      */
     public function isValid(Request $request, WebhookConfig $config): bool
     {
-        $signature = $request->get('signature', []);
+        $signature = $this->signature($request);
+
         $secret = $config->signingSecret;
 
         try {
@@ -45,5 +46,22 @@ class MailgunSignatureValidator implements SignatureValidator
         }
 
         return true;
+    }
+
+    /**
+     * Validate the incoming signature' schema
+     *
+     * @param  \Illuminate\Http\Request $request
+     * @return array
+     */
+    protected function signature(Request $request): array
+    {
+        $validated = $request->validate([
+            'signature.signature' => 'bail|required',
+            'signature.timestamp' => 'required',
+            'signature.token' => 'required',
+        ]);
+
+        return $validated['signature'];
     }
 }

--- a/src/MailgunSignatureValidator.php
+++ b/src/MailgunSignatureValidator.php
@@ -49,7 +49,7 @@ class MailgunSignatureValidator implements SignatureValidator
     }
 
     /**
-     * Validate the incoming signature' schema
+     * Validate the incoming signature' schema.
      *
      * @param  \Illuminate\Http\Request $request
      * @return array


### PR DESCRIPTION
Add validation of the request schema:
In case when a signature is bad or missing. return HTTP code 422