### PR TITLE
Make events key case insensitive

### DIFF
--- a/src/ProcessMailgunWebhookJob.php
+++ b/src/ProcessMailgunWebhookJob.php
@@ -46,7 +46,7 @@ class ProcessMailgunWebhookJob extends ProcessWebhookJob
     protected function determineJobClass(string $eventType): string
     {
         $jobConfigKey = str_replace('.', '_', $eventType);
-
-        return config("mailgun-webhooks.jobs.{$jobConfigKey}", '');
+        $jobConfigKey_lower = strtolower($jobConfigKey);
+        return config("mailgun-webhooks.jobs.{$jobConfigKey}", config("mailgun-webhooks.jobs.{$jobConfigKey_lower}", ''));
     }
 }


### PR DESCRIPTION
So mailgun appears to be insane and mixes their event names in upper and lowercase. 🤢 

For example the event type "clicked" and "opened" are sent as "CLICKED" and "OPENED" while "delivered" and "failed" are just "delivered" and "failed".

This doesn't appear to be clear in mailgun docs or mentioned in the docs here, but the config file is case sensitive so you need the same case as the mailgun event to call the right job type:
``` 
        'delivered' => \App\Jobs\Mailgun\HandleDelivered::class,
        'CLICKED' => \App\Jobs\Mailgun\HandleClicks::class,
        'complained' => \App\Jobs\Mailgun\HandleComplaints::class,
```

Rather then this project trying to advise on what mailgun's current events are, and which case they should be referenced in, this PR sets a fallback event type to use a lowercase version of the event name. 

So both the above config and the more natural setup below will work:

``` 
        'delivered' => \App\Jobs\Mailgun\HandleDelivered::class,
        'clicked' => \App\Jobs\Mailgun\HandleClicks::class,
        'complained' => \App\Jobs\Mailgun\HandleComplaints::class,
```

The fallback is a little ugly, but it should avoid breaking changes where people are using the uppercase, but allows others to use lowercase rather then go mad wondering why the one event doesn't work!
