### PR TITLE
Update README.md, fix typo

### DIFF
--- a/README.md
+++ b/README.md
@@ -189,8 +189,8 @@ Let's take a look at how you can listen for such an event. In the `EventServiceP
  * @var array
  */
 protected $listen = [
-    'mailgin-webhooks::delievered' => [
-        App\Listeners\DelieveredSource::class,
+    'mailgun-webhooks::delivered' => [
+        App\Listeners\DeliveredSource::class,
     ],
 ];
 ```
@@ -205,7 +205,7 @@ namespace App\Listeners;
 use Illuminate\Contracts\Queue\ShouldQueue;
 use Spatie\WebhookClient\Models\WebhookCall;
 
-class DelieveredSource implements ShouldQueue
+class DeliveredSource implements ShouldQueue
 {
     public function handle(WebhookCall $webhookCall)
     {


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Documentation**
	- Corrected the spelling of "delivered" in multiple locations within the README file for clarity and consistency.

- **Bug Fixes**
	- Updated the event name from `mailgin-webhooks::delievered` to `mailgun-webhooks::delivered` to ensure accurate event handling.
	- Renamed the class from `DelieveredSource` to `DeliveredSource` to prevent potential issues with event processing.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->