### PR TITLE
Fix deprecation warning

### DIFF
--- a/src/MailgunWebhooksController.php
+++ b/src/MailgunWebhooksController.php
@@ -16,7 +16,7 @@ class MailgunWebhooksController
      * @param  string|null  $configKey
      * @return \Illuminate\Http\Response
      */
-    public function __invoke(Request $request, string|null $configKey = null)
+    public function __invoke(Request $request, ?string $configKey = null)
     {
         $webhookConfig = new WebhookConfig([
             'name' => 'mailgun',

--- a/src/MailgunWebhooksController.php
+++ b/src/MailgunWebhooksController.php
@@ -16,7 +16,7 @@ class MailgunWebhooksController
      * @param  string|null  $configKey
      * @return \Illuminate\Http\Response
      */
-    public function __invoke(Request $request, string $configKey = null)
+    public function __invoke(Request $request, string|null $configKey = null)
     {
         $webhookConfig = new WebhookConfig([
             'name' => 'mailgun',


### PR DESCRIPTION
Mark the parameter as explicitly nullable per [deprecation](https://php.watch/versions/8.4/implicitly-marking-parameter-type-nullable-deprecated) warning. 